### PR TITLE
override wondows app auto start logic

### DIFF
--- a/Kooboo.App/App.xaml.cs
+++ b/Kooboo.App/App.xaml.cs
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Yardi Technology Limited. Http://www.kooboo.com 
+//Copyright (c) 2018 Yardi Technology Limited. Http://www.kooboo.com
 //All rights reserved.
 using System.Collections.Generic;
 using System.Windows;
@@ -9,7 +9,7 @@ using System.Linq;
 using System;
 
 namespace Kooboo.App
-{ 
+{
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
@@ -52,7 +52,7 @@ namespace Kooboo.App
                 ["site"] = new HomePage(),
                 ["server"] = new ServerPage(),
                 ["host"] = new HostPage(),
-                ["upgrade"]=new UpgradePage()
+                ["upgrade"] = new UpgradePage()
             };
             var btn = sender as RadioButton;
             if (btn != null && e.Source == btn)
@@ -69,25 +69,23 @@ namespace Kooboo.App
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             KoobooUpgrade.DeleteUpgradeRemainedFiles();
-            //第一次默认启动
-            if (KoobooAutoStart.IsFirstTimeAutoStart())
+
+            if (KoobooAutoStart.IsFirstTimeStart() || //first run default auto start
+                KoobooAutoStart.IsAutoStart() || //override task when application path changed
+                KoobooAutoStart.OldCodeHadSetAutoSart()) //compatible old code
             {
                 KoobooAutoStart.AutoStart(true);
             }
 
             GlobalSettings.RootPath = Kooboo.Data.AppSettings.DatabasePath;
 
-            KoobooStartUp.StartAll(); 
-         
+            KoobooStartUp.StartAll();
         }
-
 
         private void Application_Exit(object sender, ExitEventArgs e)
         {
             KoobooStartUp.StopAll();
             System.Diagnostics.Process.GetCurrentProcess().Kill();
         }
-
-        
     }
 }

--- a/Kooboo.App/Kooboo.App.csproj
+++ b/Kooboo.App/Kooboo.App.csproj
@@ -37,7 +37,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -84,6 +84,9 @@
     <StartupObject>Kooboo.App.AppProgram</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Win32.TaskScheduler, Version=2.8.7.0, Culture=neutral, PublicKeyToken=c416bc1b32d97233, processorArchitecture=MSIL">
+      <HintPath>..\packages\TaskScheduler.2.8.7\lib\net40\Microsoft.Win32.TaskScheduler.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -237,6 +240,7 @@
     </None>
     <None Include="app.Release.config" />
     <None Include="app.Server.config" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Kooboo.App/packages.config
+++ b/Kooboo.App/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="TaskScheduler" version="2.8.7" targetFramework="net45" />
+</packages>

--- a/Kooboo.Web/Kooboo.Web.csproj.user
+++ b/Kooboo.Web/Kooboo.Web.csproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup>
     <EnableSecurityDebugging>false</EnableSecurityDebugging>


### PR DESCRIPTION
Use windows task scheduler override wpf app auto start logic.
The registry mode does not work When the user open windows UAC,but the windows task scheduler works fine。
