### PR TITLE
fix 404 request delay

### DIFF
--- a/Kooboo.Sites/Repository/TransferTaskRepository.cs
+++ b/Kooboo.Sites/Repository/TransferTaskRepository.cs
@@ -269,12 +269,12 @@ namespace Kooboo.Sites.Repository
 
         public bool CanStartDownload(string relativeUrl)
         {
-
-            if (string.IsNullOrEmpty(relativeUrl))
+            // site self resource cant download
+            if (string.IsNullOrEmpty(relativeUrl)||relativeUrl.StartsWith("/"))
             {
-                relativeUrl = "/";
+                return false;
             }
-
+            
             if (!this.ContinueDownloading.ContainsKey(relativeUrl))
             {
                 // if not download yet, start download. 


### PR DESCRIPTION
When you request 404 resource twice,the last request will delay 30 second