### PR TITLE
keep string value quote in sqlServer.findAll

### DIFF
--- a/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
+++ b/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
@@ -238,13 +238,14 @@ namespace Kooboo.IndexedDB.Dynamic
             }
         }
 
-        public static List<ConditionItem> ParseConditoin(string expression)
+        public static List<ConditionItem> ParseConditoin(string expression, bool keepStringQuote = false)
         {
             if (string.IsNullOrWhiteSpace(expression))
             {
                 return new List<ConditionItem>(); 
             }
             var scanner = new SyntaxScanner(expression);
+            scanner.KeepStringQuote = keepStringQuote;
 
             var token = scanner.ConsumeNext();
 

--- a/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
+++ b/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
@@ -254,6 +254,7 @@ namespace Kooboo.IndexedDB.Dynamic
             string field = null;
             string compare = null;
             string value = null;
+            bool isValueString = false;
 
             List<ConditionItem> result = new List<ConditionItem>();
 
@@ -269,6 +270,7 @@ namespace Kooboo.IndexedDB.Dynamic
                             item.Field = field;
                             item.Comparer = GetComparer(compare);
                             item.Value = value;
+                            item.IsString = isValueString;
                             result.Add(item);
                         }
                         else
@@ -304,6 +306,7 @@ namespace Kooboo.IndexedDB.Dynamic
                     else if (value == null)
                     {
                         value = token;
+                        isValueString = tokenRet.IsString;
                     }
 
                     if (field != null && compare != null && value != null)
@@ -312,6 +315,7 @@ namespace Kooboo.IndexedDB.Dynamic
                         item.Field = field;
                         item.Comparer = GetComparer(compare);
                         item.Value = value;
+                        item.IsString = isValueString;
                         result.Add(item);
 
                         field = null;

--- a/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
+++ b/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
@@ -3,6 +3,8 @@
 using Kooboo.IndexedDB.Query;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -238,16 +240,16 @@ namespace Kooboo.IndexedDB.Dynamic
             }
         }
 
-        public static List<ConditionItem> ParseConditoin(string expression, bool keepStringQuote = false)
+        public static List<ConditionItem> ParseConditoin(string expression)
         {
             if (string.IsNullOrWhiteSpace(expression))
             {
                 return new List<ConditionItem>(); 
             }
             var scanner = new SyntaxScanner(expression);
-            scanner.KeepStringQuote = keepStringQuote;
 
-            var token = scanner.ConsumeNext();
+            var tokenRet = scanner.ConsumeNext();
+            var token = tokenRet.Value;
 
             string field = null;
             string compare = null;
@@ -318,7 +320,8 @@ namespace Kooboo.IndexedDB.Dynamic
                     }
                 }
 
-                token = scanner.ConsumeNext();
+                tokenRet = scanner.ConsumeNext();
+                token = tokenRet.Value;
             }
 
             if (field != null && compare != null)
@@ -380,8 +383,9 @@ namespace Kooboo.IndexedDB.Dynamic
 
         public Comparer Comparer { get; set; }
 
-        public string Value { get; set; }
+        public bool IsString { get; set; }
 
+        public string Value { get; set; }
     }
 
 }

--- a/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
+++ b/Kooboo.IndexedDB/Dynamic/QueryPraser.cs
@@ -249,7 +249,7 @@ namespace Kooboo.IndexedDB.Dynamic
             var scanner = new SyntaxScanner(expression);
 
             var tokenRet = scanner.ConsumeNext();
-            var token = tokenRet.Value;
+            var token = tokenRet?.Value;
 
             string field = null;
             string compare = null;
@@ -325,7 +325,7 @@ namespace Kooboo.IndexedDB.Dynamic
                 }
 
                 tokenRet = scanner.ConsumeNext();
-                token = tokenRet.Value;
+                token = tokenRet?.Value;
             }
 
             if (field != null && compare != null)

--- a/Kooboo.IndexedDB/Dynamic/SyntaxScanner.cs
+++ b/Kooboo.IndexedDB/Dynamic/SyntaxScanner.cs
@@ -70,6 +70,8 @@ namespace Kooboo.IndexedDB.Dynamic
 
         public string nexttoken { get; set; }
 
+        public bool KeepStringQuote { get; set; }
+
         public string ConsumeNext()
         {  
             while (currentIndex < totalLength)
@@ -133,7 +135,14 @@ namespace Kooboo.IndexedDB.Dynamic
                     {
                         string value = LookTill(currentChar);
 
-                        return value;   
+                        if (KeepStringQuote)
+                        {
+                            return currentChar + value + currentChar;
+                        }
+                        else
+                        {
+                            return value;
+                        }
                     }
                 }
                  

--- a/Kooboo.IndexedDB/Dynamic/SyntaxScanner.cs
+++ b/Kooboo.IndexedDB/Dynamic/SyntaxScanner.cs
@@ -3,11 +3,11 @@
 using System.Collections.Generic;
 
 namespace Kooboo.IndexedDB.Dynamic
-{ 
+{
 
     public class SyntaxScanner
     {
-        private static HashSet<char> _singleoperator; 
+        private static HashSet<char> _singleoperator;
         public static HashSet<char> SingleOperator
         {
             get
@@ -21,7 +21,7 @@ namespace Kooboo.IndexedDB.Dynamic
                     _singleoperator.Add('!');
                     _singleoperator.Add('&');
                 }
-                return _singleoperator; 
+                return _singleoperator;
             }
         }
 
@@ -44,13 +44,13 @@ namespace Kooboo.IndexedDB.Dynamic
         }
 
         private bool IsSeperator(char current)
-        { 
-            return SingleOperator.Contains(current);   
+        {
+            return SingleOperator.Contains(current);
         }
 
         public bool IsTwoCharSperator(string input)
         {
-            return DoubleOperator.Contains(input); 
+            return DoubleOperator.Contains(input);
         }
 
         public SyntaxScanner(string text)
@@ -72,8 +72,8 @@ namespace Kooboo.IndexedDB.Dynamic
 
         public bool KeepStringQuote { get; set; }
 
-        public string ConsumeNext()
-        {  
+        public TokenResult ConsumeNext()
+        {
             while (currentIndex < totalLength)
             {
                 var currentChar = this.Source[currentIndex];
@@ -83,21 +83,21 @@ namespace Kooboo.IndexedDB.Dynamic
                     if (!string.IsNullOrEmpty(currentValue))
                     {
                         string newvalue = currentValue;
-                        currentValue = string.Empty; 
-                        currentIndex += 1;  
+                        currentValue = string.Empty;
+                        currentIndex += 1;
                         return newvalue;
                     }
                     else
                     {
-                        currentIndex += 1; 
+                        currentIndex += 1;
                     }
                 }
-                else if  (IsSeperator(currentChar))
+                else if (IsSeperator(currentChar))
                 {
                     if (!string.IsNullOrEmpty(currentValue))
                     {
                         string newvalue = currentValue;
-                        currentValue = string.Empty; 
+                        currentValue = string.Empty;
                         return newvalue;
                     }
                     else
@@ -118,12 +118,12 @@ namespace Kooboo.IndexedDB.Dynamic
                                 return currentChar.ToString();
                             }
                         }
-                        currentIndex += 1; 
-                        return currentChar.ToString(); 
-                    } 
+                        currentIndex += 1;
+                        return currentChar.ToString();
+                    }
                 }
 
-                else if (currentChar=='"' || currentChar == '\'') 
+                else if (currentChar == '"' || currentChar == '\'')
                 {
                     if (!string.IsNullOrEmpty(currentValue))
                     {
@@ -134,25 +134,17 @@ namespace Kooboo.IndexedDB.Dynamic
                     else
                     {
                         string value = LookTill(currentChar);
-
-                        if (KeepStringQuote)
-                        {
-                            return currentChar + value + currentChar;
-                        }
-                        else
-                        {
-                            return value;
-                        }
+                        return new TokenResult { Value = value, IsString = true };
                     }
                 }
-                 
+
 
                 else
                 {
                     this.currentValue += currentChar;
                     currentIndex += 1;
                 }
-             
+
             }
 
             if (!string.IsNullOrEmpty(this.currentValue))
@@ -161,45 +153,59 @@ namespace Kooboo.IndexedDB.Dynamic
 
                 this.currentValue = string.Empty;
 
-                return newvalue;  
-            } 
+                return newvalue;
+            }
             return null;
-        }  
-        
+        }
+
         private char LookAhead()
         {
-            int next = this.currentIndex + 1; 
-           
+            int next = this.currentIndex + 1;
+
             if (next < this.totalLength)
             {
-                return this.Source[next]; 
+                return this.Source[next];
             }
 
-            return default(char); 
+            return default(char);
         }
 
         public string LookTill(char endchar)
         {
-            string value = string.Empty; 
+            string value = string.Empty;
 
             int next = this.currentIndex + 1;
 
             while (next < this.totalLength)
             {
-                var current = this.Source[next]; 
+                var current = this.Source[next];
                 if (current == endchar)
                 {
-                    break; 
+                    break;
                 }
                 else
                 {
-                    value += current; 
+                    value += current;
                 }
-                next += 1;  
+                next += 1;
             }
 
-            this.currentIndex = next+1; 
-            return value;   
-        }  
+            this.currentIndex = next + 1;
+            return value;
+        }
+
+
+    }
+
+    public class TokenResult
+    {
+        public string Value { get; set; }
+
+        public bool IsString { get; set; }
+
+        public static implicit operator TokenResult(string str)
+        {
+            return new TokenResult { Value = str, IsString = false };
+        }
     }
 }

--- a/Kooboo.Sites/Scripting/Global/RelationalDatabase/SqlExecuter.cs
+++ b/Kooboo.Sites/Scripting/Global/RelationalDatabase/SqlExecuter.cs
@@ -163,7 +163,7 @@ namespace Kooboo.Sites.Scripting.Global.RelationalDatabase
 
         internal string ConditionsToSql(List<ConditionItem> conditions)
         {
-            return string.Join(" and ", conditions.Select(s => $@" {WarpField(s.Field)} {ComparerToString(s.Comparer)} {ConventValue(s.Comparer, s.Value)} "));
+            return string.Join(" and ", conditions.Select(s => $@" {WarpField(s.Field)} {ComparerToString(s.Comparer)} {ConventValue(s)} "));
         }
 
         internal string WarpField(string field)
@@ -196,35 +196,26 @@ namespace Kooboo.Sites.Scripting.Global.RelationalDatabase
             }
         }
 
-        static string ConventValue(Comparer comparer, string value)
+        static string ConventValue(ConditionItem condition)
         {
-            switch (comparer)
+            switch (condition.Comparer)
             {
                 case Comparer.EqualTo:
                 case Comparer.NotEqualTo:
-
-                    if (!decimal.TryParse(value, out var _) && !bool.TryParse(value, out var _))
+                    if (condition.IsString)
                     {
-                        value = $"'{RemoveQuote(value)}'";
+                        return $"'{condition.Value}'";
                     }
-
                     break;
                 case Comparer.StartWith:
-                    value = $"'{RemoveQuote(value)}%'";
-                    break;
+                    return $"'{condition.Value}%'";
                 case Comparer.Contains:
-                    value = $"'%{RemoveQuote(value)}%'";
-                    break;
+                    return $"'%{condition.Value}%'";
                 default:
                     break;
             }
 
-            return value;
-        }
-
-        private static string RemoveQuote(string value)
-        {
-            return value.TrimStart('\'').TrimEnd('\'');
+            return condition.Value;
         }
     }
 }

--- a/Kooboo.Sites/Scripting/Global/RelationalDatabase/SqlExecuter.cs
+++ b/Kooboo.Sites/Scripting/Global/RelationalDatabase/SqlExecuter.cs
@@ -205,21 +205,26 @@ namespace Kooboo.Sites.Scripting.Global.RelationalDatabase
 
                     if (!decimal.TryParse(value, out var _) && !bool.TryParse(value, out var _))
                     {
-                        value = $"'{value}'";
+                        value = $"'{RemoveQuote(value)}'";
                     }
 
                     break;
                 case Comparer.StartWith:
-                    value = $"'{value}%'";
+                    value = $"'{RemoveQuote(value)}%'";
                     break;
                 case Comparer.Contains:
-                    value = $"'%{value}%'";
+                    value = $"'%{RemoveQuote(value)}%'";
                     break;
                 default:
                     break;
             }
 
             return value;
+        }
+
+        private static string RemoveQuote(string value)
+        {
+            return value.TrimStart('\'').TrimEnd('\'');
         }
     }
 }

--- a/Kooboo.Sites/Scripting/Global/SqlServer/SqlServerExecuter.cs
+++ b/Kooboo.Sites/Scripting/Global/SqlServer/SqlServerExecuter.cs
@@ -88,7 +88,7 @@ WHERE
 
         public override object[] QueryData(string name, string where = null, long? limit = null, long? offset = null, string orderBy = null, object @params = null)
         {
-            var conditions = IndexedDB.Dynamic.QueryPraser.ParseConditoin(where, keepStringQuote:true);
+            var conditions = IndexedDB.Dynamic.QueryPraser.ParseConditoin(where);
             var whereStr = where == null ? string.Empty : $"WHERE {ConditionsToSql(conditions)}";
             var limitStr = limit.HasValue ? $"ROW FETCH NEXT {limit} ROWS ONLY" : string.Empty;
             var orderByStr = orderBy == null ? string.Empty : $"ORDER BY {orderBy}";

--- a/Kooboo.Sites/Scripting/Global/SqlServer/SqlServerExecuter.cs
+++ b/Kooboo.Sites/Scripting/Global/SqlServer/SqlServerExecuter.cs
@@ -88,7 +88,7 @@ WHERE
 
         public override object[] QueryData(string name, string where = null, long? limit = null, long? offset = null, string orderBy = null, object @params = null)
         {
-            var conditions = IndexedDB.Dynamic.QueryPraser.ParseConditoin(where);
+            var conditions = IndexedDB.Dynamic.QueryPraser.ParseConditoin(where, keepStringQuote:true);
             var whereStr = where == null ? string.Empty : $"WHERE {ConditionsToSql(conditions)}";
             var limitStr = limit.HasValue ? $"ROW FETCH NEXT {limit} ROWS ONLY" : string.Empty;
             var orderByStr = orderBy == null ? string.Empty : $"ORDER BY {orderBy}";


### PR DESCRIPTION
现象：在 findAll(“Name=='1111111'”时报脚本错误

原因：findAll使用的是Kooboo.IndexedDB下的SyntaxScanner，Scanner去除引号读取为value，value在condition构建是通过数值parse决定是否是字串，所以当字串恰好为'111111'这样的数值字串时，最终以数值形式生成了SQL。

解决：读取时额外传参 keepStringQuote 决定是否保持value的字串引号，使得SQL生成时那边可以解析为字串。