### PR TITLE
chunk write to Kestrel Response Body

### DIFF
--- a/Kooboo.Lib/Extensions/StreamExtensions.cs
+++ b/Kooboo.Lib/Extensions/StreamExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kooboo.Extensions
+{
+    public static class StreamExtensions
+    {
+        public static async Task ChunkCopyAsync(this Stream from, Stream to, long length, int chunkSize = 2046)
+        {
+            var buffer = new byte[chunkSize];
+            var bytesRemaining = length;
+
+            while (bytesRemaining > 0)
+            {
+                int count;
+                if (bytesRemaining <= buffer.Length)
+                {
+                    count = await from.ReadAsync(buffer, 0, (int)bytesRemaining);
+                }
+                else
+                {
+                    count = await from.ReadAsync(buffer, 0, buffer.Length);
+                }
+
+                if (count == 0)
+                    return;
+
+                await to.WriteAsync(buffer, 0, count);
+
+                bytesRemaining -= count;
+            }
+        }
+
+        public static async Task ChunkCopyAsync(this byte[] from, Stream to, int chunkSize = 2046)
+        {
+            for (var i = 0; i < from.Length; i += chunkSize)
+            {
+                await to.WriteAsync(from, i, Math.Min(from.Length - i, chunkSize));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Change all the possible writing to Response.Body greater than 2K to chunk mode.
- has Response.Body value
- has Response.tream value
- has FilePart value
- StatusCode not to be 200 and has customized Body


