### PR TITLE
add async read/write timeout to smtp and imap

### DIFF
--- a/Kooboo.Mail/Imap/Server/ImapServer.cs
+++ b/Kooboo.Mail/Imap/Server/ImapServer.cs
@@ -30,6 +30,8 @@ namespace Kooboo.Mail.Imap
         {
             Port = port;
 
+            Timeout = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
+
             Heartbeat = Heartbeat.Instance;
             _connectionManager = new ConnectionManager(Options.MaxConnections);
             Heartbeat.Add(_connectionManager);
@@ -60,6 +62,8 @@ namespace Kooboo.Mail.Imap
             }
         }
 
+        public int Timeout { get; set; }
+
         [JsonIgnore]
         public X509Certificate Certificate { get; private set; }
 
@@ -75,6 +79,8 @@ namespace Kooboo.Mail.Imap
                 return;
 
             _listener = new TcpListener(new IPEndPoint(IPAddress.Any, Port));
+            _listener.Server.ReceiveTimeout =
+            _listener.Server.SendTimeout = Timeout;
             _listener.Start();
 
             _cancellationTokenSource = new CancellationTokenSource();

--- a/Kooboo.Mail/Imap/Server/ImapSession.cs
+++ b/Kooboo.Mail/Imap/Server/ImapSession.cs
@@ -116,7 +116,10 @@ namespace Kooboo.Mail.Imap
                 }
                 else
                 {
-                    Stream = new ImapStream(TcpClient, TcpClient.GetStream());
+                    var stream = TcpClient.GetStream();
+                    stream.ReadTimeout =
+                    stream.WriteTimeout = Server.Timeout;
+                    Stream = new ImapStream(TcpClient, stream);
                 }
 
                 await OnStart();
@@ -140,6 +143,9 @@ namespace Kooboo.Mail.Imap
             {
                 // No need to dispose for finally block will do it
             }
+            catch (SocketException)
+            {
+            }
             catch (Exception ex)
             {
                 await Stream.WriteLineAsync("Local server error occured, bye!");
@@ -158,6 +164,8 @@ namespace Kooboo.Mail.Imap
 
             IsSecureConnection = true;
 
+            sslStream.ReadTimeout =
+            sslStream.WriteTimeout = Server.Timeout;
             Stream = new ImapStream(TcpClient, sslStream);
         }
 

--- a/Kooboo.Mail/Imap/Server/ImapStream.cs
+++ b/Kooboo.Mail/Imap/Server/ImapStream.cs
@@ -8,7 +8,8 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
-using LumiSoft.Net; 
+using LumiSoft.Net;
+using Kooboo.Mail.Smtp;
 
 namespace Kooboo.Mail.Imap
 {
@@ -41,7 +42,7 @@ namespace Kooboo.Mail.Imap
             int hasRead = 0, actual = 0;
             do
             {
-                actual = await _stream.ReadAsync(buffer, offset + hasRead, count - hasRead);
+                actual = await _stream.ReadAsyncWithTimeout(buffer, offset + hasRead, count - hasRead);
 
                 hasRead += actual;
             }
@@ -61,7 +62,7 @@ namespace Kooboo.Mail.Imap
 
         public virtual async Task<string> ReadLineAsync()
         {
-            var line = await _reader.ReadLineAsync();
+            var line = await _reader.ReadToEndAsyncWithTimeout();
 
             LogRead(line);
 
@@ -70,7 +71,7 @@ namespace Kooboo.Mail.Imap
 
         public virtual async Task WriteAsync(byte[] buffer)
         {
-            await _stream.WriteAsync(buffer, 0, buffer.Length);
+            await _stream.WriteAsyncWithTimeout(buffer, 0, buffer.Length);
             await _stream.FlushAsync();
 
             var str = Encoding.UTF8.GetString(buffer);
@@ -85,7 +86,7 @@ namespace Kooboo.Mail.Imap
 
         public virtual async Task WriteLineAsync(string line)
         {
-            await _writer.WriteAsync(line + "\r\n");
+            await _writer.WriteLineAsyncWithTimeout(line);
 
             LogWrite(line);
         }

--- a/Kooboo.Mail/Smtp/SmtpServer.cs
+++ b/Kooboo.Mail/Smtp/SmtpServer.cs
@@ -41,6 +41,8 @@ namespace Kooboo.Mail.Smtp
             Port = port;
             Certificate = cert;
 
+            Timeout = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
+
             Heartbeat = Heartbeat.Instance;
             _connectionManager = new ConnectionManager(Options.MaxConnections);
             Heartbeat.Add(_connectionManager);
@@ -149,7 +151,7 @@ namespace Kooboo.Mail.Smtp
         public SmtpServerOptions()
         {
 
-            this.LiveTimeout = TimeSpan.FromSeconds(30);
+            this.LiveTimeout = TimeSpan.FromMinutes(1);
             this.MailsPerConnection = 10;
 
 #if DEBUG


### PR DESCRIPTION
- Set server object Timeout value to Stream.ReadTimeout and Stream.WriteTimeout.
- Add timeout control to basic Stream/StreamReader read/write operations based on Stream.ReadTimeout and Stream.WriteTimeout value.
- Change all the read/write calling to those basic operations.
- Catch SocketException(Timeout) in connection loop
- Change default Timeout value from 30 seconds to 1 minute for Gmail/Hotmail normally behave on this value.